### PR TITLE
Prevent from failing using an extra protocol in resolver's URL

### DIFF
--- a/modules/sbt-plugin-1_3_11/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin_1_3_11.scala
+++ b/modules/sbt-plugin-1_3_11/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin_1_3_11.scala
@@ -52,12 +52,12 @@ object StewardPlugin_1_3_11 extends AutoPlugin {
           )
         val dependencies = libraryDeps ++ scalafixDeps
 
-        def getCredentials(url: URL, name: String): Option[Resolver.Credentials] =
+        def getCredentials(host: String, name: String): Option[Resolver.Credentials] =
           (for {
             allDirect <- Try(Credentials.allDirect(sbtCredentials)).toOption
-            maybeRealmAndHost = allDirect.find(c => c.realm == name && c.host == url.getHost)
+            maybeRealmAndHost = allDirect.find(c => c.realm == name && c.host == host)
             maybeRealm = allDirect.find(_.realm == name)
-            maybeHost = allDirect.find(_.host == url.getHost)
+            maybeHost = allDirect.find(_.host == host)
           } yield maybeRealmAndHost.orElse(maybeRealm).orElse(maybeHost)).flatten
             .map(c => Resolver.Credentials(c.userName, c.passwd))
 
@@ -69,16 +69,17 @@ object StewardPlugin_1_3_11 extends AutoPlugin {
             (headerKey, headerValue) <- authentication.headers
           } yield Resolver.Header(headerKey, headerValue)
 
+        // may include protocols other than http/https which may fail on constructing a java.net.URL
+        def getHost(uri: String): Option[String] =
+          Try(new URL(uri).getHost).orElse(Try(new URI(uri).getHost)).toOption
+
         val resolvers = fullResolvers.value.collect {
           case repo: MavenRepository if !repo.root.startsWith("file:") =>
-            val creds =
-              if (Set("http:", "https:").exists(repo.root.startsWith))
-                getCredentials(new URL(repo.root), repo.name)
-              else None
+            val creds = getHost(repo.root).flatMap(getCredentials(_, repo.name))
             Resolver.MavenRepository(repo.name, repo.root, creds, getHeaders(repo.name))
           case repo: URLRepository =>
             val ivyPatterns = repo.patterns.ivyPatterns.mkString
-            val creds = getCredentials(new URL(ivyPatterns), repo.name)
+            val creds = getHost(ivyPatterns).flatMap(getCredentials(_, repo.name))
             Resolver.IvyRepository(repo.name, ivyPatterns, creds, getHeaders(repo.name))
         }
 

--- a/modules/sbt-plugin-1_3_11/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin_1_3_11.scala
+++ b/modules/sbt-plugin-1_3_11/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin_1_3_11.scala
@@ -52,7 +52,7 @@ object StewardPlugin_1_3_11 extends AutoPlugin {
           )
         val dependencies = libraryDeps ++ scalafixDeps
 
-        def getCredentials(url: URI, name: String): Option[Resolver.Credentials] =
+        def getCredentials(url: URL, name: String): Option[Resolver.Credentials] =
           (for {
             allDirect <- Try(Credentials.allDirect(sbtCredentials)).toOption
             maybeRealmAndHost = allDirect.find(c => c.realm == name && c.host == url.getHost)
@@ -70,12 +70,14 @@ object StewardPlugin_1_3_11 extends AutoPlugin {
           } yield Resolver.Header(headerKey, headerValue)
 
         val resolvers = fullResolvers.value.collect {
-          case repo: MavenRepository if !repo.root.startsWith("file:") =>
-            val creds = getCredentials(new URI(repo.root), repo.name)
+          case repo: MavenRepository if Set("http:", "https:").exists(repo.root.startsWith) =>
+            val creds = getCredentials(new URL(repo.root), repo.name)
             Resolver.MavenRepository(repo.name, repo.root, creds, getHeaders(repo.name))
+          case repo: MavenRepository =>
+            Resolver.MavenRepository(repo.name, repo.root, None, getHeaders(repo.name))
           case repo: URLRepository =>
             val ivyPatterns = repo.patterns.ivyPatterns.mkString
-            val creds = getCredentials(new URI(ivyPatterns), repo.name)
+            val creds = getCredentials(new URL(ivyPatterns), repo.name)
             Resolver.IvyRepository(repo.name, ivyPatterns, creds, getHeaders(repo.name))
         }
 

--- a/modules/sbt-plugin-1_3_11/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin_1_3_11.scala
+++ b/modules/sbt-plugin-1_3_11/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin_1_3_11.scala
@@ -52,7 +52,7 @@ object StewardPlugin_1_3_11 extends AutoPlugin {
           )
         val dependencies = libraryDeps ++ scalafixDeps
 
-        def getCredentials(url: URL, name: String): Option[Resolver.Credentials] =
+        def getCredentials(url: URI, name: String): Option[Resolver.Credentials] =
           (for {
             allDirect <- Try(Credentials.allDirect(sbtCredentials)).toOption
             maybeRealmAndHost = allDirect.find(c => c.realm == name && c.host == url.getHost)
@@ -71,11 +71,11 @@ object StewardPlugin_1_3_11 extends AutoPlugin {
 
         val resolvers = fullResolvers.value.collect {
           case repo: MavenRepository if !repo.root.startsWith("file:") =>
-            val creds = getCredentials(new URL(repo.root), repo.name)
+            val creds = getCredentials(new URI(repo.root), repo.name)
             Resolver.MavenRepository(repo.name, repo.root, creds, getHeaders(repo.name))
           case repo: URLRepository =>
             val ivyPatterns = repo.patterns.ivyPatterns.mkString
-            val creds = getCredentials(new URL(ivyPatterns), repo.name)
+            val creds = getCredentials(new URI(ivyPatterns), repo.name)
             Resolver.IvyRepository(repo.name, ivyPatterns, creds, getHeaders(repo.name))
         }
 

--- a/modules/sbt-plugin-1_3_11/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin_1_3_11.scala
+++ b/modules/sbt-plugin-1_3_11/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin_1_3_11.scala
@@ -70,11 +70,12 @@ object StewardPlugin_1_3_11 extends AutoPlugin {
           } yield Resolver.Header(headerKey, headerValue)
 
         val resolvers = fullResolvers.value.collect {
-          case repo: MavenRepository if Set("http:", "https:").exists(repo.root.startsWith) =>
-            val creds = getCredentials(new URL(repo.root), repo.name)
+          case repo: MavenRepository if !repo.root.startsWith("file:") =>
+            val creds =
+              if (Set("http:", "https:").exists(repo.root.startsWith))
+                getCredentials(new URL(repo.root), repo.name)
+              else None
             Resolver.MavenRepository(repo.name, repo.root, creds, getHeaders(repo.name))
-          case repo: MavenRepository =>
-            Resolver.MavenRepository(repo.name, repo.root, None, getHeaders(repo.name))
           case repo: URLRepository =>
             val ivyPatterns = repo.patterns.ivyPatterns.mkString
             val creds = getCredentials(new URL(ivyPatterns), repo.name)


### PR DESCRIPTION
Hi, after we added a resolver with a custom protocol in the URL, like `artifactregistry://example.com/maven` we got `java.net.MalformedURLException` exceptions from this plugin. I tried to change it to use `java.net.URI` instead, but it was throwing exceptions in another place, so I tried to get the host from one of them as in this PR and it seemed to work.

Example URL/URI outputs:
```scala
scala> URI("artifactregistry://example.com").getHost
val res2: String = example.com
                                                                                                                                                                                                                 
scala> URL("artifactregistry://example.com").getHost
java.net.MalformedURLException: unknown protocol: artifactregistry
```

Related PR on extra protocol handlers: https://github.com/scala-steward-org/scala-steward/pull/2628 