### PR TITLE
Use `scalafixScalaBinaryVersion` for scala-fix rules

### DIFF
--- a/modules/sbt-plugin-1_0_0/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin_1_0_0.scala
+++ b/modules/sbt-plugin-1_0_0/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin_1_0_0.scala
@@ -40,13 +40,15 @@ object StewardPlugin_1_0_0 extends AutoPlugin {
         val libraryDeps = libraryDependencies.value
           .map(moduleId => toDependency(moduleId, scalaVersionValue, scalaBinaryVersionValue))
 
+        val scalafixScalaBinaryVersion = findScalafixScalaBinaryVersion.value.getOrElse("2.12")
+
         val scalafixDeps = findScalafixDependencies.value
           .getOrElse(Seq.empty)
           .map(moduleId =>
             toDependency(
               moduleId,
-              scalaVersionValue,
-              scalaBinaryVersionValue,
+              "", // scalafix rules don't require a scalaVersion
+              scalafixScalaBinaryVersion,
               Some("scalafix-rule")
             )
           )
@@ -87,6 +89,17 @@ object StewardPlugin_1_0_0 extends AutoPlugin {
       val scalafixDependencies = SettingKey[Seq[ModuleID]]("scalafixDependencies").?
       Def.setting {
         scalafixDependencies.value
+      }
+    } catch {
+      case _: ClassNotFoundException => Def.setting(None)
+    }
+  }
+
+  lazy val findScalafixScalaBinaryVersion: Def.Initialize[Option[String]] = Def.settingDyn {
+    try {
+      val scalafixScalaBinaryVersion = SettingKey[String]("scalafixScalaBinaryVersion").?
+      Def.setting {
+        scalafixScalaBinaryVersion.value
       }
     } catch {
       case _: ClassNotFoundException => Def.setting(None)

--- a/modules/sbt-plugin-1_3_11/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin_1_3_11.scala
+++ b/modules/sbt-plugin-1_3_11/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin_1_3_11.scala
@@ -40,13 +40,15 @@ object StewardPlugin_1_3_11 extends AutoPlugin {
         val libraryDeps = libraryDependencies.value
           .map(moduleId => toDependency(moduleId, scalaVersionValue, scalaBinaryVersionValue))
 
+        val scalafixScalaBinaryVersion = findScalafixScalaBinaryVersion.value.getOrElse("2.12")
+
         val scalafixDeps = findScalafixDependencies.value
           .getOrElse(Seq.empty)
           .map(moduleId =>
             toDependency(
               moduleId,
-              scalaVersionValue,
-              scalaBinaryVersionValue,
+              "", // scalafix rules don't require a scalaVersion
+              scalafixScalaBinaryVersion,
               Some("scalafix-rule")
             )
           )
@@ -99,6 +101,17 @@ object StewardPlugin_1_3_11 extends AutoPlugin {
       val scalafixDependencies = SettingKey[Seq[ModuleID]]("scalafixDependencies").?
       Def.setting {
         scalafixDependencies.value
+      }
+    } catch {
+      case _: ClassNotFoundException => Def.setting(None)
+    }
+  }
+
+  lazy val findScalafixScalaBinaryVersion: Def.Initialize[Option[String]] = Def.settingDyn {
+    try {
+      val scalafixScalaBinaryVersion = SettingKey[String]("scalafixScalaBinaryVersion").?
+      Def.setting {
+        scalafixScalaBinaryVersion.value
       }
     } catch {
       case _: ClassNotFoundException => Def.setting(None)


### PR DESCRIPTION
The `sbt-scalafix` plugin uses `scalafixScalaBinaryVersion` to load it's rules.

This plugin was using till now `scalaBinaryVersion` . This pull request fixes this behaviour.

Fixes: scala-steward-org/scala-steward#1413 (was already closed)