### PR TITLE
Remove deprecated URL constructor

### DIFF
--- a/modules/sbt-plugin-1_3_11/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin_1_3_11.scala
+++ b/modules/sbt-plugin-1_3_11/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin_1_3_11.scala
@@ -73,7 +73,7 @@ object StewardPlugin_1_3_11 extends AutoPlugin {
 
         // may include protocols other than http/https which may fail on constructing a java.net.URL
         def getHost(uri: String): Option[String] =
-          Try(new URL(uri).getHost).orElse(Try(new URI(uri).getHost)).toOption
+          Try(new URI(uri).getHost).toOption
 
         val resolvers = fullResolvers.value.collect {
           case repo: MavenRepository if !repo.root.startsWith("file:") =>


### PR DESCRIPTION
I noticed this during my regular Steward run:

```
[warn] /builds/apps/dependency-scanning/scala-steward/steward-workspace/repos/myprojecthere/project/scala-steward-StewardPlugin_1_3_11.scala:76:15: constructor URL in class URL is deprecated
[warn]           Try(new URL(uri).getHost).orElse(Try(new URI(uri).getHost)).toOption
[warn]               ^
[warn] one warning found
[debug] Scala compilation took 2.07477969 s
[info] done compiling
```

-- deprecated in Java 20 ([reference](https://docs.oracle.com/en/java/javase/20/docs/api/java.base/java/net/URL.html#constructor-deprecation))

I can't see any tests in the project, does anyone have a good way of verifying?

I thought about this alternative but it feels like it might be fruitless if they both pass through `URI.apply` - `Try(new URI(uri).toURL.getHost).orElse(Try(new URI(uri).getHost)).toOption` - WDYT?