### PR TITLE
Include dependency overrides in list of dependencies to update

### DIFF
--- a/modules/sbt-plugin-1_0_0/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin_1_0_0.scala
+++ b/modules/sbt-plugin-1_0_0/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin_1_0_0.scala
@@ -40,6 +40,9 @@ object StewardPlugin_1_0_0 extends AutoPlugin {
         val libraryDeps = libraryDependencies.value
           .map(moduleId => toDependency(moduleId, scalaVersionValue, scalaBinaryVersionValue))
 
+        val dependencyOverrides = Keys.dependencyOverrides.value
+          .map(moduleId => toDependency(moduleId, scalaVersionValue, scalaBinaryVersionValue))
+
         val scalafixScalaBinaryVersion = findScalafixScalaBinaryVersion.value.getOrElse("2.12")
 
         val scalafixDeps = findScalafixDependencies.value
@@ -52,7 +55,7 @@ object StewardPlugin_1_0_0 extends AutoPlugin {
               Some("scalafix-rule")
             )
           )
-        val dependencies = libraryDeps ++ scalafixDeps
+        val dependencies = libraryDeps ++ scalafixDeps ++ dependencyOverrides
 
         def getCredentials(url: URL, name: String): Option[Resolver.Credentials] =
           (for {

--- a/modules/sbt-plugin-1_3_11/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin_1_3_11.scala
+++ b/modules/sbt-plugin-1_3_11/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin_1_3_11.scala
@@ -16,8 +16,9 @@
 
 package org.scalasteward.sbt.plugin
 
-import sbt.Keys._
-import sbt._
+import sbt.*
+import sbt.Keys.*
+
 import scala.util.Try
 
 object StewardPlugin_1_3_11 extends AutoPlugin {
@@ -28,7 +29,7 @@ object StewardPlugin_1_3_11 extends AutoPlugin {
       taskKey[Unit]("Prints dependencies and resolvers as JSON for consumption by Scala Steward.")
   }
 
-  import autoImport._
+  import autoImport.*
 
   override def projectSettings: Seq[Def.Setting[_]] =
     Seq(
@@ -38,6 +39,9 @@ object StewardPlugin_1_3_11 extends AutoPlugin {
         val sbtCredentials = findCredentials.value
 
         val libraryDeps = libraryDependencies.value
+          .map(moduleId => toDependency(moduleId, scalaVersionValue, scalaBinaryVersionValue))
+
+        val dependencyOverrides = Keys.dependencyOverrides.value
           .map(moduleId => toDependency(moduleId, scalaVersionValue, scalaBinaryVersionValue))
 
         val scalafixScalaBinaryVersion = findScalafixScalaBinaryVersion.value.getOrElse("2.12")
@@ -52,7 +56,7 @@ object StewardPlugin_1_3_11 extends AutoPlugin {
               Some("scalafix-rule")
             )
           )
-        val dependencies = libraryDeps ++ scalafixDeps
+        val dependencies = libraryDeps ++ scalafixDeps ++ dependencyOverrides
 
         def getCredentials(host: String, name: String): Option[Resolver.Credentials] =
           (for {

--- a/modules/sbt-plugin-1_3_11/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin_1_3_11.scala
+++ b/modules/sbt-plugin-1_3_11/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin_1_3_11.scala
@@ -16,8 +16,8 @@
 
 package org.scalasteward.sbt.plugin
 
-import sbt.*
-import sbt.Keys.*
+import sbt._
+import sbt.Keys._
 
 import scala.util.Try
 
@@ -29,7 +29,7 @@ object StewardPlugin_1_3_11 extends AutoPlugin {
       taskKey[Unit]("Prints dependencies and resolvers as JSON for consumption by Scala Steward.")
   }
 
-  import autoImport.*
+  import autoImport._
 
   override def projectSettings: Seq[Def.Setting[_]] =
     Seq(


### PR DESCRIPTION
Often time vulnerabilities are found in transitive dependencies, if you list all your project's dependencies (including transitive) in `dependencyOverrides` and we enable Scala Steward to check for library upgrades to `dependencyOverrides` then Scala Steward can help automatically keep transitive dependencies up to date.